### PR TITLE
fix copying of licenses and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ copr repository available at: https://copr.fedorainfracloud.org/coprs/almac/jmc-
 `$ fedpkg srpm`
 
 optionally, can create a Fedora version-specific srpm:
-`$fedpkg --release f33 srpm` would create a srpm for Fedora 33
+`$ fedpkg --release f33 srpm` would create a srpm for Fedora 33
 
 ### Building the package locally (mock)
 If I'm looking to create a mock build for Fedora 33 using the first iteration of this package, my command might look something like:</br>

--- a/jmc-agent.spec
+++ b/jmc-agent.spec
@@ -57,8 +57,7 @@ This package contains javadoc for %{summary}.
 
 %patch0 -p1
 
-cp ../license/* ./
-cp ../README.md ./
+cp ./license/* ./
 
 %pom_remove_plugin :maven-enforcer-plugin
 %pom_remove_plugin :maven-failsafe-plugin
@@ -82,5 +81,5 @@ cp ../README.md ./
 %doc README.md
 
 %changelog
-* Wed Dec 01 2021 Alex Macdonald <almacdon@redhat.com> - 1.0.1-1
+* Fri Dec 03 2021 Alex Macdonald <almacdon@redhat.com> - 1.0.1-1
 - Initial package


### PR DESCRIPTION
This small PR addresses the two open issues about the readme and licenses being copied from the main jmc repo instead of the agent directory.

https://github.com/aptmac/jmc-agent/issues/1
https://github.com/aptmac/jmc-agent/issues/2